### PR TITLE
Fix a flaky test by cleaning a polluted state

### DIFF
--- a/test/test_occam_data.py
+++ b/test/test_occam_data.py
@@ -99,6 +99,7 @@ def test_occam_data_constructor_files():
 def test_occam_data_attributes():
     occam_data, fort1, fort7, xyz = _create_default_occam_data_object()
     _assert_all_attributes_present_and_equal(occam_data, fort1, fort7, xyz)
+    shutil.rmtree(class_dir)
 
 
 def test_occam_data_wrong_input():
@@ -214,19 +215,6 @@ def test_occam_data_progress_bars():
 
 
 def test_occam_data_not_save_to_npy():
-    (occam_data, fort1, fort7, xyz) = _create_default_occam_data_object()
-    all_attributes = [key for key in occam_data.__dict__]
-    attributes = []
-    for key in all_attributes:
-        assert (key in occam_data.__dict__)
-    occam_data_npy_loaded = OccamData(os.path.join(class_dir, os.pardir), silent=True)
-    try:
-        _ = OccamData('this_is_not_a_file', silent=True)
-    except FileNotFoundError:
-        caught = True
-    assert caught
-    shutil.rmtree(class_dir)
-  
     assert not os.path.exists(class_dir)
     _ = OccamData(file_name_fort_1, save_to_npy=False, silent=True)
     assert not os.path.exists(class_dir)

--- a/test/test_occam_data.py
+++ b/test/test_occam_data.py
@@ -214,6 +214,19 @@ def test_occam_data_progress_bars():
 
 
 def test_occam_data_not_save_to_npy():
+    (occam_data, fort1, fort7, xyz) = _create_default_occam_data_object()
+    all_attributes = [key for key in occam_data.__dict__]
+    attributes = []
+    for key in all_attributes:
+        assert (key in occam_data.__dict__)
+    occam_data_npy_loaded = OccamData(os.path.join(class_dir, os.pardir), silent=True)
+    try:
+        _ = OccamData('this_is_not_a_file', silent=True)
+    except FileNotFoundError:
+        caught = True
+    assert caught
+    shutil.rmtree(class_dir)
+  
     assert not os.path.exists(class_dir)
     _ = OccamData(file_name_fort_1, save_to_npy=False, silent=True)
     assert not os.path.exists(class_dir)


### PR DESCRIPTION
# What is the purpose of the change
This PR is to fix a flaky test `test/test_occam_data.py::test_occam_data_not_save_to_npy`, which can fail after running `test/test_occam_data.py::test_occam_data_attributes`, but passes when it is run in isolation.

# Reproduce the test failure
Run the following command:
```
python -m pytest test/test_occam_data.py::test_occam_data_attributes test/test_occam_data.py::test_occam_data_not_save_to_npy
```
# Expected result
`test/test_occam_data.py::test_occam_data_not_save_to_npy` should pass after running `test/test_occam_data.py::test_occam_data_attributes`.

# Actual result
```
    def test_occam_data_not_save_to_npy():
>       assert not os.path.exists(class_dir)
E       AssertionError: assert not True
E        +  where True = <function exists at 0x7f3b6d24cca0>('/home/yyy/pythonOD/explore_test/cprojects/OccamTools/test/../data/class_data')
E        +    where <function exists at 0x7f3b6d24cca0> = <module 'posixpath' from '/usr/lib/python3.8/posixpath.py'>.exists
E        +      where <module 'posixpath' from '/usr/lib/python3.8/posixpath.py'> = os.path

test/test_occam_data.py:217: AssertionError
```
# Why it fails
- The test class directory is not deleted after running `test/test_occam_data.py::test_occam_data_attributes`.
# Fix
- Delete `class_dir` at the end of `test/test_occam_data.py::test_occam_data_attributes`
